### PR TITLE
Remove unused Grid import from About component

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Button, Chip, Container, Grid, Paper, Typography } from '@mui/material';
+import { Box, Button, Chip, Container, Paper, Typography } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import { motion } from 'framer-motion';
 


### PR DESCRIPTION
## Summary
- clean up About component imports by removing unused Grid

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68403c26e0ac83218df1742aa4487b24