### PR TITLE
Apply Geist font across site

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans);
 }


### PR DESCRIPTION
## Summary
- use Geist font as the global body font

## Testing
- `npx --yes jest` *(fails: Cannot find module 'next/jest')*
- `npx next lint` *(fails: needs to install next)*

------
https://chatgpt.com/codex/tasks/task_e_684046c2089c8321a8aac70a9341e02d